### PR TITLE
Fix bad 'unique' properties for some metaclasses

### DIFF
--- a/pygeppetto/model/datasources/datasources.py
+++ b/pygeppetto/model/datasources/datasources.py
@@ -103,7 +103,7 @@ class QueryMatchingCriteria(EObject):
 
 
 class QueryResult(AQueryResult):
-    values = EAttribute(eType=EJavaObject, upper=-1)
+    values = EAttribute(eType=EJavaObject, upper=-1, unique=False)
 
     def __init__(self, values=None, **kwargs):
         super(QueryResult, self).__init__(**kwargs)
@@ -112,7 +112,7 @@ class QueryResult(AQueryResult):
 
 
 class SerializableQueryResult(AQueryResult):
-    values = EAttribute(eType=EString, upper=-1)
+    values = EAttribute(eType=EString, upper=-1, unique=False)
 
     def __init__(self, values=None, **kwargs):
         super(SerializableQueryResult, self).__init__(**kwargs)

--- a/pygeppetto/model/values/values.py
+++ b/pygeppetto/model/values/values.py
@@ -135,7 +135,7 @@ class Unit(Value):
 
 class TimeSeries(Value):
     scalingFactor = EAttribute(eType=EInt)
-    value = EAttribute(eType=EDouble, upper=-1)
+    value = EAttribute(eType=EDouble, upper=-1, unique=False)
     unit = EReference(containment=True)
 
     def __init__(self, unit=None, scalingFactor=None, value=None, **kwargs):
@@ -447,4 +447,3 @@ class SkeletonAnimation(VisualValue):
         super(SkeletonAnimation, self).__init__(**kwargs)
         if skeletonTransformationSeries:
             self.skeletonTransformationSeries.extend(skeletonTransformationSeries)
-


### PR DESCRIPTION
Fix for 'QueryResult', 'SerializableQueryResult' and 'TimeSeries'.

Sorry, I need to investigate to see if the error came from a bad handling on my side or if it comes from a bad generation. Sorry again...